### PR TITLE
RS-4919: Claims API - Add search by Last Modified Date

### DIFF
--- a/source/includes/_appointment.md
+++ b/source/includes/_appointment.md
@@ -131,7 +131,7 @@ Searches for all appointments matching the given search criteria. See [https://w
 #### Parameters
 | Name | Located in | Description | Required | Initial Version |
 | ---- | ---------- | ----------- | -------- | --------------- |
-| _lastUpdated | query | The date the appointment was last modified formatted as yyyy-MM-dd. As of version 14.3, we also support the format yyyy-MM-ddThh:mm:ss\[Z\|(+\|-)hh:mm\] | No | _12.8_ |
+| _lastUpdated | query | The date the appointment was last modified formatted as yyyy-MM-dd. As of version 14.3, we also support the format yyyy-MM-ddThh:mm:ss\[Z&#124;(+&#124;-)hh:mm\] | No | _12.8_ |
 | identifier | query | The unique identifier for a single appointment | No | _12.6_ |
 | patient | query | The unique identifier acquired from the patient search or a patient chart number | No | _12.6_ |
 | date | query | The appointment start date. When searching for appointments within a date range, the following prefixes may be used: lt, gt, eq, le, ge | No | _12.6_ |

--- a/source/includes/_claim.md
+++ b/source/includes/_claim.md
@@ -144,7 +144,7 @@ Searches for all  based on the given search criteria.
 #### Parameters
 | Name | Located in | Description | Required | Initial Version |
 | ---- | ---------- | ----------- | -------- | --------------- |
-| _lastUpdated | query | The date the claim was last modified formatted as yyyy-MM-dd. We also support the format yyyy-MM-ddThh:mm:ss\[Z\|(+\|-)hh:mm\] | No | _14.3_ |
+| _lastUpdated | query | The date the claim was last modified formatted as yyyy-MM-dd. We also support the format yyyy-MM-ddThh:mm:ss\[Z&#124;(+&#124;-)hh:mm\] | No | _14.3_ |
 | identifier | query or uri | The unique value assigned to each Claim which discerns it from all others. |  No | _12.9.20_ |
 | use | query | The use of the Claim. (exploratory for quote or complete for bill) | No | _12.9.20_ |
 | facility | query | The place of service for the Claim. | No | _12.9.20_ |

--- a/source/includes/_patient.md
+++ b/source/includes/_patient.md
@@ -362,7 +362,7 @@ Searches for all patients matching the given search criteria. See [https://www.h
 #### Parameters
 | Name | Located in | Description | Required | Type | Initial Version |
 | ---- | ---------- | ----------- | -------- | ---- | --------------- |
-| _lastUpdated | query | The date the patient was last modified formatted as yyyy-MM-dd. As of version 14.3, we also support the format yyyy-MM-ddThh:mm:ss\[Z\|(+\|-)hh:mm\] | No | dateTime | _12.8_ |
+| _lastUpdated | query | The date the patient was last modified formatted as yyyy-MM-dd. As of version 14.3, we also support the format yyyy-MM-ddThh:mm:ss\[Z&#124;(+&#124;-)hh:mm\] | No | dateTime | _12.8_ |
 | family | query | The family (last) name of the patient | No | string | _12.6_ |
 | given | query | The given (first) name of the patient | No | string | _12.6_ |
 | birthdate | query | The patient's date of birth formatted as YYYY-MM-DD | No | dateTime | _12.6_ |
@@ -406,7 +406,7 @@ _At least one of query parameters is required to perform a search._
 ### Parameters
 | Name | Located in | Description | Required | Type | Initial Version |
 | ---- | ---------- | ----------- | -------- | ---- | --------------- |
-| _lastUpdated | query | The date the patient was last modified formatted as yyyy-MM-dd. As of version 14.3, we also support the format yyyy-MM-ddThh:mm:ss\[Z\|(+\|-)hh:mm\] | No | dateTime | _12.8_ |
+| _lastUpdated | query | The date the patient was last modified formatted as yyyy-MM-dd. As of version 14.3, we also support the format yyyy-MM-ddThh:mm:ss\[Z&#124;(+&#124;-)hh:mm\] | No | dateTime | _12.8_ |
 | family | query | The family (last) name of the patient | No | string | _12.6_ |
 | given | query | The given (first) name of the patient | No | string | _12.6_ |
 | birthdate | query | The patient's date of birth formatted as YYYY-MM-DD | No | dateTime | _12.6_ |

--- a/source/includes/_paymentreconciliation.md
+++ b/source/includes/_paymentreconciliation.md
@@ -171,7 +171,7 @@ Searches for all  based on the given search criteria.
 #### Parameters
 | Name | Located in | Description | Required | Initial Version |
 | ---- | ---------- | ----------- | -------- | --------------- |
-| _lastUpdated | query | The date the payment was last modified formatted as yyyy-MM-dd. We also support the format yyyy-MM-ddThh:mm:ss\[Z\|(+\|-)hh:mm\] | No | _14.3_ |
+| _lastUpdated | query | The date the payment was last modified formatted as yyyy-MM-dd. We also support the format yyyy-MM-ddThh:mm:ss\[Z&#124;(+&#124;-)hh:mm\] | No | _14.3_ |
 | identifier | query or uri | The unique value assigned to each PaymentReconciliation. |  No | _14.2_ |
 | location.id | query | The location for the PaymentReconciliation. | No | _14.2_ |
 | patient | query | The patient the PaymentReconciliation is tied to. | No | _14.2_ |


### PR DESCRIPTION
+ Turns out the engine we use to generate html out of md files doesn't like \| to escape |, so using the code for | instead: &#124;