### PR TITLE
No ID - Make documentation deploy automatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ For assistance or additional instructions please visit the official Slate readme
 
 You can publish the contents of this repository to https://nextechsystems.github.io/selectapidocspub by doing the following:
 
-1. Cloning https://github.com/NextechSystems/selectapidocspub to a Mac OS machine
-2. Open a new Terminal or Command Shell window 
-3. Browse into the path of your cloned repository on your local machine
-4. Type in `./deploy.sh`
+EITHER run it automatically:
 
-It takes a few minutes for the changes to go live.
+1. Run the Azure Devops Pipeline: https://dev.azure.com/nextech-systems/select-partnerapi/_build?definitionId=333&_a=summary
+
+OR run it manually:
+
+1. Clone this repository to a Mac OS machine
+1. Open a new Terminal or Command Shell window to the path of your checkout
+1. If you haven't done so before (see setup above), type in `bundle install`
+1. Type in `./deploy.sh`
+
+The changes will appear immediately in the `gh-pages` branch of this repository, but it takes a few minutes to go live on github pages.

--- a/deploy.sh
+++ b/deploy.sh
@@ -166,9 +166,7 @@ commit+push() {
 
   disable_expanded_output
   #--quiet is important here to avoid outputting the repo URL, which may contain a secret token
-  #Nextech - to work around the 'terminal prompts disabled' error, set the user.name on the command line
-  echo git -c user.name="deploy.sh" push --quiet $repo $deploy_branch
-  git -c user.name="deploy.sh" push --quiet $repo $deploy_branch
+  git push --quiet $repo $deploy_branch
   enable_expanded_output
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -70,7 +70,7 @@ parse_args() {
 
   # Source directory & target branch.
   deploy_directory=build
-  deploy_branch=noid_experimentalbuild1
+  deploy_branch=gh-pages
 
   #if no user identity is already set in the current git environment, use this:
   default_username=${GIT_DEPLOY_USERNAME:-deploy.sh}

--- a/deploy.sh
+++ b/deploy.sh
@@ -81,9 +81,6 @@ parse_args() {
 
   #append commit hash to the end of message by default
   append_hash=${GIT_DEPLOY_APPEND_HASH:-true}
-
-  #include optional command headers for the git push operation
-  push_command_headers=${GIT_PUSH_COMMAND_HEADERS:-}
 }
 
 main() {
@@ -169,7 +166,8 @@ commit+push() {
 
   disable_expanded_output
   #--quiet is important here to avoid outputting the repo URL, which may contain a secret token
-  git -c user.name="$default_username" push --quiet $repo $deploy_branch
+  #Nextech - to work around the 'terminal prompts disabled' error, set the user.name on the command line
+  git -c user.name="deploy.sh" push --quiet $repo $deploy_branch
   enable_expanded_output
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -70,7 +70,7 @@ parse_args() {
 
   # Source directory & target branch.
   deploy_directory=build
-  deploy_branch=gh-pages
+  deploy_branch=noid_experimentalbuild1
 
   #if no user identity is already set in the current git environment, use this:
   default_username=${GIT_DEPLOY_USERNAME:-deploy.sh}

--- a/deploy.sh
+++ b/deploy.sh
@@ -169,7 +169,7 @@ commit+push() {
 
   disable_expanded_output
   #--quiet is important here to avoid outputting the repo URL, which may contain a secret token
-  git $push_command_headers push --quiet $repo $deploy_branch
+  git -c user.name="$default_username" push --quiet $repo $deploy_branch
   enable_expanded_output
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -77,7 +77,7 @@ parse_args() {
   default_email=${GIT_DEPLOY_EMAIL:-}
 
   #repository to deploy to. must be readable and writable.
-  repo=origin
+  repo=${GIT_REPO:-origin}
 
   #append commit hash to the end of message by default
   append_hash=${GIT_DEPLOY_APPEND_HASH:-true}

--- a/deploy.sh
+++ b/deploy.sh
@@ -167,6 +167,7 @@ commit+push() {
   disable_expanded_output
   #--quiet is important here to avoid outputting the repo URL, which may contain a secret token
   #Nextech - to work around the 'terminal prompts disabled' error, set the user.name on the command line
+  echo git -c user.name="deploy.sh" push --quiet $repo $deploy_branch
   git -c user.name="deploy.sh" push --quiet $repo $deploy_branch
   enable_expanded_output
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -169,7 +169,7 @@ commit+push() {
 
   disable_expanded_output
   #--quiet is important here to avoid outputting the repo URL, which may contain a secret token
-  git push --quiet $push_command_headers $repo $deploy_branch
+  git $push_command_headers push --quiet $repo $deploy_branch
   enable_expanded_output
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -81,6 +81,9 @@ parse_args() {
 
   #append commit hash to the end of message by default
   append_hash=${GIT_DEPLOY_APPEND_HASH:-true}
+
+  #include optional command headers for the git push operation
+  push_command_headers=${GIT_PUSH_COMMAND_HEADERS:-}
 }
 
 main() {
@@ -166,7 +169,7 @@ commit+push() {
 
   disable_expanded_output
   #--quiet is important here to avoid outputting the repo URL, which may contain a secret token
-  git push --quiet $repo $deploy_branch
+  git push --quiet $push_command_headers $repo $deploy_branch
   enable_expanded_output
 }
 


### PR DESCRIPTION
* Added `GIT_REPO` environment variable to the deploy script so that we could pass in credentials from Azure Devops Pipelines, thus making the documentation deploy automatable
* Improved readme to be more clear about manual deploy and also reference the automated deploy (pipeline)