### PR TITLE
AR-15059 - Add new immunization fields

### DIFF
--- a/source_r4/includes/_patient.md
+++ b/source_r4/includes/_patient.md
@@ -972,8 +972,8 @@ The immunization resource describes an administered vaccine.
 | ---- | ----------- | ---- | --------------- |
 | id | The logical id of the resource, as used in the URL for the resource. | [string](https://www.hl7.org/fhir/R4/datatypes.html#string) | _16.7_ |
 | identifier | The unique value assigned to each immunization which discerns them from all others. | [Identifier](https://www.hl7.org/fhir/R4/datatypes.html#Identifier) | _16.7_ |
-| status | Either `completed` or `entered-in-error` or `not-done` | [code](https://hl7.org/fhir/R4/datatypes.html#code) with [immunization status value set](https://hl7.org/fhir/R4/valueset-immunization-status.html) | _16.7_ |
-| statusReason | Reason that an immunization event was not performed, if any | [CodeableConcept](https://www.hl7.org/fhir/R4/datatypes.html#CodeableConcept) using [immunization status reason value set](https://www.hl7.org/fhir/R4/valueset-immunization-status-reason.htmll) | _16.7_ |
+| status | Either `completed` or `not-done` | [code](https://hl7.org/fhir/R4/datatypes.html#code) with [immunization status value set](https://hl7.org/fhir/R4/valueset-immunization-status.html) | _16.7_ |
+| statusReason | Reason that an immunization event was not performed, if any | [CodeableConcept](https://www.hl7.org/fhir/R4/datatypes.html#CodeableConcept) using [ActReason value set](https://hl7.org/fhir/R4/v3/ActReason/cs.html) | _16.7_ |
 | vaccineCode | Vaccine product administered | [CodeableConcept](https://www.hl7.org/fhir/R4/datatypes.html#CodeableConcept) using [vaccine administered value set](https://www.hl7.org/fhir/R4/valueset-vaccine-code.html) | _16.7_ |
 | patient | The immunized patient | [Reference](https://www.hl7.org/fhir/R4/references.html) ([USCorePatientProfile](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-patient.html)) | _16.7_ |
 | occurrenceDateTime | The vaccination administration date in the form YYYY-MM-DD | [dateTime](https://www.hl7.org/fhir/R4/datatypes.html#dateTime) | _16.7_ |
@@ -1010,7 +1010,7 @@ The immunization resource describes an administered vaccine.
           "display": "Tinsley, Carol F"
         },
         "occurrenceDateTime": "2013-08-17",
-        "primarySource" : false
+        "primarySource" : true
       }
     }
   ]

--- a/source_r4/includes/_patient.md
+++ b/source_r4/includes/_patient.md
@@ -973,7 +973,7 @@ The immunization resource describes an administered vaccine.
 | id | The logical id of the resource, as used in the URL for the resource. | [string](https://www.hl7.org/fhir/R4/datatypes.html#string) | _16.7_ |
 | identifier | The unique value assigned to each immunization which discerns them from all others. | [Identifier](https://www.hl7.org/fhir/R4/datatypes.html#Identifier) | _16.7_ |
 | status | Either `completed` or `not-done` | [code](https://hl7.org/fhir/R4/datatypes.html#code) with [immunization status value set](https://hl7.org/fhir/R4/valueset-immunization-status.html) | _16.7_ |
-| statusReason | Reason that an immunization event was not performed, if any | [CodeableConcept](https://www.hl7.org/fhir/R4/datatypes.html#CodeableConcept) using [ActReason value set](https://hl7.org/fhir/R4/v3/ActReason/cs.html) | _16.7_ |
+| statusReason | Reason that an immunization event was not performed, if any | [CodeableConcept](https://www.hl7.org/fhir/R4/datatypes.html#CodeableConcept) using [Substance Refusal Reason (NIP) value set](https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.114222.4.5.294) | _16.7_ |
 | vaccineCode | Vaccine product administered | [CodeableConcept](https://www.hl7.org/fhir/R4/datatypes.html#CodeableConcept) using [vaccine administered value set](https://www.hl7.org/fhir/R4/valueset-vaccine-code.html) | _16.7_ |
 | patient | The immunized patient | [Reference](https://www.hl7.org/fhir/R4/references.html) ([USCorePatientProfile](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-patient.html)) | _16.7_ |
 | occurrenceDateTime | The vaccination administration date in the form YYYY-MM-DD | [dateTime](https://www.hl7.org/fhir/R4/datatypes.html#dateTime) | _16.7_ |


### PR DESCRIPTION
@NextechSystems/the-architects 

This is just a simple tweak to the current R4 immunization documentation, to account for the `statusReason` value set, and the fact that we're currently always returning `true` for `primarySource`.

The related PRs for this are:
https://github.com/NextechSystems/nx/pull/4926
https://github.com/NextechSystems/select-partnerapi/pull/139